### PR TITLE
Fix inconsistency between Objective-C and Swift example

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,9 +325,9 @@ func application(_ application: UIApplication, open url: URL, sourceApplication:
 }
 
 func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
-    Branch.getInstance().continue(userActivity)
+    let handledByBranch = Branch.getInstance().continue(userActivity)
 
-    return true
+    return handledByBranch
 }
 
 func application(_ application: UIApplication, didReceiveRemoteNotification launchOptions: [AnyHashable: Any]) -> Void {


### PR DESCRIPTION
In Swift example method `application(_:continue:restorationHandler:)` returns always `true` and ignoring Branch response. It's fine in Objective-C example.

